### PR TITLE
[feat] 카테고리 목록 API

### DIFF
--- a/src/main/java/com/moneyplan/category/controller/CategoryController.java
+++ b/src/main/java/com/moneyplan/category/controller/CategoryController.java
@@ -1,0 +1,30 @@
+package com.moneyplan.category.controller;
+
+import com.moneyplan.category.dto.CategoryRes;
+import com.moneyplan.category.service.CategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "카테고리")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/categories")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping("/")
+    @Operation(summary = "카테고리 목록", description = "카테고리 목록을 반환합니다.")
+    public ResponseEntity<List<CategoryRes>> getCategories() {
+        List<CategoryRes> res = categoryService.getCategories();
+
+        return ResponseEntity.ok(res);
+    }
+
+}

--- a/src/main/java/com/moneyplan/category/dto/CategoryRes.java
+++ b/src/main/java/com/moneyplan/category/dto/CategoryRes.java
@@ -1,0 +1,14 @@
+package com.moneyplan.category.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CategoryRes {
+
+    private String name;
+
+    public CategoryRes(String name) {
+        this.name = name;
+    }
+
+}

--- a/src/main/java/com/moneyplan/category/service/CategoryService.java
+++ b/src/main/java/com/moneyplan/category/service/CategoryService.java
@@ -1,0 +1,31 @@
+package com.moneyplan.category.service;
+
+import com.moneyplan.category.domain.Category;
+import com.moneyplan.category.dto.CategoryRes;
+import com.moneyplan.category.repository.CategoryRepository;
+import com.moneyplan.common.exception.BusinessException;
+import com.moneyplan.common.exception.ErrorCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public List<CategoryRes> getCategories() {
+
+        List<Category> categories = categoryRepository.findAll();
+
+        if (categories.isEmpty()) {
+            throw new BusinessException(ErrorCode.CATEGORY_NOT_FOUND);
+        }
+        return categories.stream()
+            .map(category -> new CategoryRes(category.getName()))
+            .toList();
+    }
+}

--- a/src/main/java/com/moneyplan/common/exception/ErrorCode.java
+++ b/src/main/java/com/moneyplan/common/exception/ErrorCode.java
@@ -18,6 +18,12 @@ public enum ErrorCode {
     MISSING_PARAMETER_EXCEPTION(HttpStatus.BAD_REQUEST, "필수 요청 값이 누락되었거나 잘못되었습니다."),
 
     /**
+     * 404 - Not Found
+     */
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
+
+
+    /**
      * 500 - Internal Server Error
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다.")

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,2 +1,16 @@
 INSERT IGNORE INTO member (id, account, password)
 VALUES (1, 'moneyplan', '$2a$10$cAz0EmZYfqzngI46j91lX.GdJ9hlmYbMsOa5Esr0Hh.rwyfDb8dYW');
+
+INSERT IGNORE INTO category (name)
+VALUES
+('식비'),
+('교통'),
+('주거/통신'),
+('생활'),
+('패션'),
+('여가'),
+('여행'),
+('쇼핑'),
+('의료'),
+('교육'),
+('기타');


### PR DESCRIPTION
## 🔥 구현 기능
> 카테고리 목록을 반환하는 API입니다.

## 🔥 구현 방법
- 어플리케이션 실행 시 카테고리 데이터 자동 저장
  - 식비, 교통, 주거/통신, 패션, 생활, 의료, 여가, 교육, 여행, 쇼핑, 기타
- 카테고리 목록 반환
  - 카테고리 데이터가 없는 경우에 대한 예외 처리

## 🔥 관련 이슈
related: #5
    
## 참고 할만한 자료(선택)
