### PR TITLE
[feat] 예산 설정 API

### DIFF
--- a/src/main/java/com/moneyplan/budget/controller/BudgetController.java
+++ b/src/main/java/com/moneyplan/budget/controller/BudgetController.java
@@ -1,0 +1,32 @@
+package com.moneyplan.budget.controller;
+
+import com.moneyplan.budget.dto.BudgetCreateReq;
+import com.moneyplan.budget.dto.BudgetCreateRes;
+import com.moneyplan.budget.service.BudgetService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "예산")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/budgets")
+public class BudgetController {
+
+    private final BudgetService budgetService;
+
+    @PostMapping("/")
+    @Operation(summary = "예산 설정", description = "기간별 예산을 설정합니다.")
+    public ResponseEntity<List<BudgetCreateRes>> createBudget(@RequestBody BudgetCreateReq req) {
+        List<BudgetCreateRes> res = budgetService.createBudget(req);
+        return ResponseEntity.ok(res);
+    }
+
+}

--- a/src/main/java/com/moneyplan/budget/domain/Budget.java
+++ b/src/main/java/com/moneyplan/budget/domain/Budget.java
@@ -10,11 +10,15 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Budget {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,11 +33,21 @@ public class Budget {
     private Category category;
 
     @Column(nullable = false)
-    private LocalDateTime period_start;
+    private LocalDate startDate;
 
     @Column(nullable = false)
-    private LocalDateTime period_end;
+    private LocalDate endDate;
 
     @Column(nullable = false)
     private int amount;
+
+    @Builder
+    public Budget(Member member, Category category, LocalDate startDate, LocalDate endDate,
+        int amount) {
+        this.member = member;
+        this.category = category;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.amount = amount;
+    }
 }

--- a/src/main/java/com/moneyplan/budget/dto/BudgetCreateReq.java
+++ b/src/main/java/com/moneyplan/budget/dto/BudgetCreateReq.java
@@ -1,0 +1,26 @@
+package com.moneyplan.budget.dto;
+
+import com.moneyplan.budget.domain.Budget;
+import com.moneyplan.category.domain.Category;
+import com.moneyplan.member.domain.Member;
+import java.time.LocalDate;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class BudgetCreateReq {
+
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Map<String, Integer> categoryBudgets;
+
+    public Budget toBudget(Member member, Category category, int amount) {
+        return Budget.builder()
+            .member(member)
+            .category(category)
+            .startDate(startDate)
+            .endDate(endDate)
+            .amount(amount)
+            .build();
+    }
+}

--- a/src/main/java/com/moneyplan/budget/dto/BudgetCreateRes.java
+++ b/src/main/java/com/moneyplan/budget/dto/BudgetCreateRes.java
@@ -1,0 +1,30 @@
+package com.moneyplan.budget.dto;
+
+import com.moneyplan.budget.domain.Budget;
+import com.moneyplan.category.dto.CategoryRes;
+import com.moneyplan.member.dto.MemberRes;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BudgetCreateRes {
+    private Long id;
+    private MemberRes member;
+    private CategoryRes category;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private int amount;
+
+    public static BudgetCreateRes of(Budget budget) {
+        return BudgetCreateRes.builder()
+            .id(budget.getId())
+            .member(MemberRes.of(budget.getMember()))
+            .category(CategoryRes.of(budget.getCategory()))
+            .startDate(budget.getStartDate())
+            .endDate(budget.getEndDate())
+            .amount(budget.getAmount())
+            .build();
+    }
+}

--- a/src/main/java/com/moneyplan/budget/service/BudgetService.java
+++ b/src/main/java/com/moneyplan/budget/service/BudgetService.java
@@ -1,0 +1,53 @@
+package com.moneyplan.budget.service;
+
+import com.moneyplan.budget.domain.Budget;
+import com.moneyplan.budget.dto.BudgetCreateReq;
+import com.moneyplan.budget.dto.BudgetCreateRes;
+import com.moneyplan.budget.repository.BudgetRepository;
+import com.moneyplan.category.domain.Category;
+import com.moneyplan.category.repository.CategoryRepository;
+import com.moneyplan.common.exception.BusinessException;
+import com.moneyplan.common.exception.ErrorCode;
+import com.moneyplan.member.domain.Member;
+import com.moneyplan.member.repository.MemberRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BudgetService {
+
+    private final CategoryRepository categoryRepository;
+    private final MemberRepository memberRepository;
+    private final BudgetRepository budgetRepository;
+
+    @Transactional
+    public List<BudgetCreateRes> createBudget(BudgetCreateReq req) {
+
+        // 회원가입/로그인 구현 전 임시 코드
+        Member member = memberRepository.findById(1L)
+            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        // 임시 코드 끝
+
+        List<BudgetCreateRes> res = new ArrayList<>();
+
+        req.getCategoryBudgets().forEach((categoryName, amount) -> {
+            if (amount < 0) {
+                throw new BusinessException(ErrorCode.INVALID_AMOUNT_EXCEPTION);
+            }
+            Category category = categoryRepository.findByName(categoryName)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+
+            Budget budget = req.toBudget(member, category, amount);
+            budgetRepository.save(budget);
+
+            res.add(BudgetCreateRes.of(budget));
+        });
+
+        return res;
+    }
+}

--- a/src/main/java/com/moneyplan/category/dto/CategoryRes.java
+++ b/src/main/java/com/moneyplan/category/dto/CategoryRes.java
@@ -1,14 +1,20 @@
 package com.moneyplan.category.dto;
 
+import com.moneyplan.category.domain.Category;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class CategoryRes {
 
+    private Long id;
     private String name;
 
-    public CategoryRes(String name) {
-        this.name = name;
+    public static CategoryRes of(Category category) {
+        return CategoryRes.builder()
+            .id(category.getId())
+            .name(category.getName())
+            .build();
     }
-
 }

--- a/src/main/java/com/moneyplan/category/repository/CategoryRepository.java
+++ b/src/main/java/com/moneyplan/category/repository/CategoryRepository.java
@@ -1,10 +1,11 @@
 package com.moneyplan.category.repository;
 
 import com.moneyplan.category.domain.Category;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-
+    Optional<Category> findByName(String name);
 }

--- a/src/main/java/com/moneyplan/category/service/CategoryService.java
+++ b/src/main/java/com/moneyplan/category/service/CategoryService.java
@@ -25,7 +25,7 @@ public class CategoryService {
             throw new BusinessException(ErrorCode.CATEGORY_NOT_FOUND);
         }
         return categories.stream()
-            .map(category -> new CategoryRes(category.getName()))
+            .map(category -> CategoryRes.of(category))
             .toList();
     }
 }

--- a/src/main/java/com/moneyplan/common/exception/ErrorCode.java
+++ b/src/main/java/com/moneyplan/common/exception/ErrorCode.java
@@ -16,10 +16,12 @@ public enum ErrorCode {
     METHOD_ARGUMENT_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "입력된 값이 유효하지 않습니다. 각 파라미터의 조건을 확인해 주세요."),
     INVALID_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, "요청된 데이터의 형식이 잘못되었습니다. 유효한 JSON 형식을 사용해 주세요."),
     MISSING_PARAMETER_EXCEPTION(HttpStatus.BAD_REQUEST, "필수 요청 값이 누락되었거나 잘못되었습니다."),
+    INVALID_AMOUNT_EXCEPTION(HttpStatus.BAD_REQUEST, "예산 금액은 0 이상이어야 합니다."),
 
     /**
      * 404 - Not Found
      */
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 멤버입니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
 
 

--- a/src/main/java/com/moneyplan/member/dto/MemberRes.java
+++ b/src/main/java/com/moneyplan/member/dto/MemberRes.java
@@ -1,0 +1,20 @@
+package com.moneyplan.member.dto;
+
+import com.moneyplan.member.domain.Member;
+import jakarta.persistence.Column;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberRes {
+    private Long id;
+    private String account;
+
+    public static MemberRes of(Member member) {
+        return MemberRes.builder()
+            .id(member.getId())
+            .account(member.getAccount())
+            .build();
+    }
+}

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -22,8 +22,8 @@ CREATE TABLE IF NOT EXISTS category
 CREATE TABLE IF NOT EXISTS budget
 (
     id          BIGINT auto_increment PRIMARY KEY,
-    period_start TIMESTAMP(6) NOT NULL,
-    period_end TIMESTAMP(6) NOT NULL,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
     amount       INT NOT NULL,
     member_id     BIGINT NOT NULL,
     category_id     BIGINT NOT NULL,


### PR DESCRIPTION
## 🔥 구현 기능
> 기간별 예산을 설정합니다. 각 예산당 카테고리는 필수로 지정해야 합니다.

## 🔥 구현 방법
- 시작일과 종료일, 각 카테고리별 예산을 request로 받습니다.
- 예산 금액은 0 이상이어야 합니다.
- 모든 카테고리는 기존에 존재하는 카테고리와 동일한 이름이어야 합니다.
- 위 조건이 모두 충족한다면 카테고리별 예산을 생성합니다.

- 클린코드를 위해 toEntity, of 메서드를 활용했습니다.

## 🔥 관련 이슈
related: #6
    
## 참고 할만한 자료(선택)
