### PR TITLE
[feat] 지출 기록 생성 API

### DIFF
--- a/src/main/java/com/moneyplan/expense/controller/ExpenseController.java
+++ b/src/main/java/com/moneyplan/expense/controller/ExpenseController.java
@@ -1,0 +1,30 @@
+package com.moneyplan.expense.controller;
+
+import com.moneyplan.expense.dto.ExpenseCreateReq;
+import com.moneyplan.expense.dto.ExpenseCreateRes;
+import com.moneyplan.expense.service.ExpenseService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "지출")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/expenses")
+public class ExpenseController {
+
+    private final ExpenseService expenseService;
+
+    @PostMapping("/")
+    @Operation(summary = "지출 생성", description = "지출 기록을 생성합니다.")
+    public ResponseEntity<ExpenseCreateRes> createExpense(@RequestBody ExpenseCreateReq req) {
+        ExpenseCreateRes res = expenseService.createExpense(req);
+        return ResponseEntity.ok(res);
+    }
+
+}

--- a/src/main/java/com/moneyplan/expense/domain/Expense.java
+++ b/src/main/java/com/moneyplan/expense/domain/Expense.java
@@ -1,5 +1,6 @@
 package com.moneyplan.expense.domain;
 
+import com.moneyplan.category.domain.Category;
 import com.moneyplan.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -23,6 +24,10 @@ public class Expense {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
 
     @Column(nullable = false)
     private LocalDateTime spent_at;

--- a/src/main/java/com/moneyplan/expense/domain/Expense.java
+++ b/src/main/java/com/moneyplan/expense/domain/Expense.java
@@ -11,11 +11,15 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Expense {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,7 +34,7 @@ public class Expense {
     private Category category;
 
     @Column(nullable = false)
-    private LocalDateTime spent_at;
+    private LocalDateTime spentAt;
 
     @Column(nullable = false)
     private int amount;
@@ -40,5 +44,16 @@ public class Expense {
 
     @Column(nullable = false, columnDefinition = "TINYINT(1)")
     @ColumnDefault("0")
-    private boolean is_total_excluded;
+    private boolean isTotalExcluded;
+
+    @Builder
+    public Expense(Member member, Category category, LocalDateTime spentAt, int amount, String memo,
+        boolean isTotalExcluded) {
+        this.member = member;
+        this.category = category;
+        this.spentAt = spentAt;
+        this.amount = amount;
+        this.memo = memo;
+        this.isTotalExcluded = isTotalExcluded;
+    }
 }

--- a/src/main/java/com/moneyplan/expense/dto/ExpenseCreateReq.java
+++ b/src/main/java/com/moneyplan/expense/dto/ExpenseCreateReq.java
@@ -1,0 +1,28 @@
+package com.moneyplan.expense.dto;
+
+import com.moneyplan.category.domain.Category;
+import com.moneyplan.expense.domain.Expense;
+import com.moneyplan.member.domain.Member;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class ExpenseCreateReq {
+
+    private Long categoryId;
+    private LocalDateTime spentAt;
+    private int amount;
+    private String memo;
+    private boolean isTotalExcluded;
+
+    public Expense toExpense(Member member, Category category) {
+        return Expense.builder()
+            .member(member)
+            .category(category)
+            .spentAt(spentAt)
+            .amount(amount)
+            .memo(memo)
+            .isTotalExcluded(isTotalExcluded)
+            .build();
+    }
+}

--- a/src/main/java/com/moneyplan/expense/dto/ExpenseCreateRes.java
+++ b/src/main/java/com/moneyplan/expense/dto/ExpenseCreateRes.java
@@ -1,0 +1,34 @@
+package com.moneyplan.expense.dto;
+
+import com.moneyplan.category.dto.CategoryRes;
+import com.moneyplan.expense.domain.Expense;
+import com.moneyplan.member.dto.MemberRes;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExpenseCreateRes {
+
+    private Long id;
+    private MemberRes member;
+    private CategoryRes category;
+    private LocalDateTime spentAt;
+    private int amount;
+    private String memo;
+    private boolean isTotalExcluded;
+
+    public static ExpenseCreateRes of(Expense expense) {
+        return ExpenseCreateRes.builder()
+            .id(expense.getId())
+            .member(MemberRes.of(expense.getMember()))
+            .category(CategoryRes.of(expense.getCategory()))
+            .spentAt(expense.getSpentAt())
+            .amount(expense.getAmount())
+            .memo(expense.getMemo())
+            .isTotalExcluded(expense.isTotalExcluded())
+            .build();
+    }
+
+}

--- a/src/main/java/com/moneyplan/expense/service/ExpenseService.java
+++ b/src/main/java/com/moneyplan/expense/service/ExpenseService.java
@@ -1,0 +1,42 @@
+package com.moneyplan.expense.service;
+
+import com.moneyplan.category.domain.Category;
+import com.moneyplan.category.repository.CategoryRepository;
+import com.moneyplan.common.exception.BusinessException;
+import com.moneyplan.common.exception.ErrorCode;
+import com.moneyplan.expense.domain.Expense;
+import com.moneyplan.expense.dto.ExpenseCreateReq;
+import com.moneyplan.expense.dto.ExpenseCreateRes;
+import com.moneyplan.expense.repository.ExpenseRepository;
+import com.moneyplan.member.domain.Member;
+import com.moneyplan.member.repository.MemberRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ExpenseService {
+
+    private final ExpenseRepository expenseRepository;
+    private final MemberRepository memberRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public ExpenseCreateRes createExpense(ExpenseCreateReq req) {
+
+        // 회원가입/로그인 구현 전 임시 코드
+        Member member = memberRepository.findById(1L)
+            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        // 임시 코드 끝
+
+        Category category = categoryRepository.findById(req.getCategoryId())
+            .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+
+        Expense expense = req.toExpense(member, category);
+        expenseRepository.save(expense);
+
+        return ExpenseCreateRes.of(expense);
+    }
+}

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -39,7 +39,9 @@ CREATE TABLE IF NOT EXISTS expense
     memo VARCHAR(1000) NULL,
     is_total_excluded TINYINT DEFAULT 0 NOT NULL,
     member_id     BIGINT NOT NULL,
-    CONSTRAINT fk_member_expense FOREIGN KEY (member_id) REFERENCES member (id)
+    category_id     BIGINT NOT NULL,
+    CONSTRAINT fk_member_expense FOREIGN KEY (member_id) REFERENCES member (id),
+    CONSTRAINT fk_category_expense FOREIGN KEY (category_id) REFERENCES category (id)
 );
 
 CREATE TABLE IF NOT EXISTS category_average_budget


### PR DESCRIPTION
## 🔥 구현 기능
> 지출 기록을 생성하는 API를 구현합니다.

## 🔥 구현 방법
- Expense 테이블에 Category 연관관계가 설정되어 있지 않아, 일대다 연관관계를 추가했습니다.
- 사용자의 지출 데이터를 받아 지출 기록을 생성합니다.

## 🔥 관련 이슈
related: #10
    
## 참고 할만한 자료(선택)
