### PR TITLE
[feat] 로그인 API 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,4 @@ jobs:
           elif [ "${{ github.ref_name }}" = "main" ]; then
             PROFILE="prod"
           fi
-          ./gradlew clean build -Pprofile=$PROFILE
+          ./gradlew clean build -Pprofile=$PROFILE -i

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,4 @@ jobs:
           elif [ "${{ github.ref_name }}" = "main" ]; then
             PROFILE="prod"
           fi
-          ./gradlew clean build -Pprofile=$PROFILE -i
+          ./gradlew clean build -Pprofile=$PROFILE

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ jacocoTestReport {
 			classDirectories.setFrom(
 					files(classDirectories.files.collect {
 						fileTree(dir: it, excludes: [
-								"com/tenten/damoa/**/domain/**",
+								"com/moneyplan/**/model/**",
 								"**/*Application*",
 								"**/*Config*",
 								"**/*Req*",

--- a/src/main/java/com/moneyplan/budget/controller/BudgetController.java
+++ b/src/main/java/com/moneyplan/budget/controller/BudgetController.java
@@ -3,6 +3,8 @@ package com.moneyplan.budget.controller;
 import com.moneyplan.budget.dto.BudgetCreateReq;
 import com.moneyplan.budget.dto.BudgetCreateRes;
 import com.moneyplan.budget.service.BudgetService;
+import com.moneyplan.common.auth.model.AuthUser;
+import com.moneyplan.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -24,8 +26,9 @@ public class BudgetController {
 
     @PostMapping("/")
     @Operation(summary = "예산 설정", description = "기간별 예산을 설정합니다.")
-    public ResponseEntity<List<BudgetCreateRes>> createBudget(@RequestBody BudgetCreateReq req) {
-        List<BudgetCreateRes> res = budgetService.createBudget(req);
+    public ResponseEntity<List<BudgetCreateRes>> createBudget(@AuthUser Member member,
+        @RequestBody BudgetCreateReq req) {
+        List<BudgetCreateRes> res = budgetService.createBudget(member, req);
         return ResponseEntity.ok(res);
     }
 

--- a/src/main/java/com/moneyplan/budget/dto/BudgetCreateRes.java
+++ b/src/main/java/com/moneyplan/budget/dto/BudgetCreateRes.java
@@ -11,7 +11,6 @@ import lombok.Getter;
 @Builder
 public class BudgetCreateRes {
     private Long id;
-    private MemberRes member;
     private CategoryRes category;
     private LocalDate startDate;
     private LocalDate endDate;
@@ -20,7 +19,6 @@ public class BudgetCreateRes {
     public static BudgetCreateRes of(Budget budget) {
         return BudgetCreateRes.builder()
             .id(budget.getId())
-            .member(MemberRes.of(budget.getMember()))
             .category(CategoryRes.of(budget.getCategory()))
             .startDate(budget.getStartDate())
             .endDate(budget.getEndDate())

--- a/src/main/java/com/moneyplan/budget/service/BudgetService.java
+++ b/src/main/java/com/moneyplan/budget/service/BudgetService.java
@@ -26,13 +26,11 @@ public class BudgetService {
     private final BudgetRepository budgetRepository;
 
     @Transactional
-    public List<BudgetCreateRes> createBudget(BudgetCreateReq req) {
+    public List<BudgetCreateRes> createBudget(Member member, BudgetCreateReq req) {
 
-        // 회원가입/로그인 구현 전 임시 코드
-        Member member = memberRepository.findById(1L)
-            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-        // 임시 코드 끝
-
+        if (member == null) {
+            throw new BusinessException(ErrorCode.MISSING_AUTHENTICATION);
+        }
         List<BudgetCreateRes> res = new ArrayList<>();
 
         req.getCategoryBudgets().forEach((categoryName, amount) -> {

--- a/src/main/java/com/moneyplan/common/auth/CustomUserDetailService.java
+++ b/src/main/java/com/moneyplan/common/auth/CustomUserDetailService.java
@@ -1,0 +1,28 @@
+package com.moneyplan.common.auth;
+
+import com.moneyplan.common.exception.BusinessException;
+import com.moneyplan.common.exception.ErrorCode;
+import com.moneyplan.member.domain.Member;
+import com.moneyplan.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        Member member = memberRepository.findById(Long.valueOf(username))
+            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        return new MemberAdapter(member);
+    }
+}

--- a/src/main/java/com/moneyplan/common/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moneyplan/common/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,79 @@
+package com.moneyplan.common.auth;
+
+
+import static com.moneyplan.common.auth.model.SecurityConstants.PERMITTED_URI;
+
+import com.moneyplan.common.auth.model.JwtRule;
+import com.moneyplan.common.exception.BusinessException;
+import com.moneyplan.common.exception.ErrorCode;
+import com.moneyplan.member.domain.Member;
+import com.moneyplan.member.repository.MemberRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtService jwtService;
+    private final MemberRepository memberRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        if (isPermittedURI(request.getRequestURI())) {
+            SecurityContextHolder.getContext().setAuthentication(null);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String accessToken = jwtService.resolveTokenFromCookie(request, JwtRule.ACCESS_PREFIX);
+        if (jwtService.validateAccessToken(accessToken)) {
+            setAuthenticationToContext(accessToken);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String refreshToken = jwtService.resolveTokenFromCookie(request, JwtRule.REFRESH_PREFIX);
+        Member member = findMemberByRefreshToken(refreshToken);
+
+        if (jwtService.validateRefreshToken(refreshToken, member.getId())) {
+
+            String reissuedAccessToken = jwtService.generateAccessToken(response, member);
+            jwtService.generateRefreshToken(response, member);
+
+            setAuthenticationToContext(reissuedAccessToken);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        jwtService.logout(member, response);
+    }
+
+    private boolean isPermittedURI(String requestURI) {
+        return Arrays.stream(PERMITTED_URI)
+            .anyMatch(permitted -> {
+                String replace = permitted.replace("*", "");
+                return requestURI.contains(replace) || replace.contains(requestURI);
+            });
+    }
+
+    private Member findMemberByRefreshToken(String refreshToken) {
+        String id = jwtService.getIdFromRefresh(refreshToken);
+        return memberRepository.findById(Long.valueOf(id))
+            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private void setAuthenticationToContext(String token) {
+        Authentication authentication = jwtService.getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+}

--- a/src/main/java/com/moneyplan/common/auth/JwtService.java
+++ b/src/main/java/com/moneyplan/common/auth/JwtService.java
@@ -40,10 +40,10 @@ public class JwtService {
 
     public JwtService(CustomUserDetailService customUserDetailService, JwtGenerator jwtGenerator,
         JwtUtil jwtUtil, RefreshTokenRepository refreshTokenRepository,
-        @Value("${jwt.key.access}") String ACCESS_SECRET_KEY,
-        @Value("${jwt.key.refresh}") String REFRESH_SECRET_KEY,
-        @Value("${jwt.time.access}") long ACCESS_EXPIRATION,
-        @Value("${jwt.time.access}") long REFRESH_EXPIRATION
+        @Value("${ACCESS_SECRET}") String ACCESS_SECRET_KEY,
+        @Value("${REFRESH_SECRET}") String REFRESH_SECRET_KEY,
+        @Value("${ACCESS_EXPIRATION}") long ACCESS_EXPIRATION,
+        @Value("${REFRESH_EXPIRATION}") long REFRESH_EXPIRATION
     ) {
         this.customUserDetailService = customUserDetailService;
         this.jwtGenerator = jwtGenerator;

--- a/src/main/java/com/moneyplan/common/auth/JwtService.java
+++ b/src/main/java/com/moneyplan/common/auth/JwtService.java
@@ -40,10 +40,10 @@ public class JwtService {
 
     public JwtService(CustomUserDetailService customUserDetailService, JwtGenerator jwtGenerator,
         JwtUtil jwtUtil, RefreshTokenRepository refreshTokenRepository,
-        @Value("${jwt.key.access}") String ACCESS_SECRET_KEY,
-        @Value("${jwt.key.refresh}") String REFRESH_SECRET_KEY,
-        @Value("${jwt.time.access}") long ACCESS_EXPIRATION,
-        @Value("${jwt.time.refresh}") long REFRESH_EXPIRATION
+        @Value("${ACCESS_SECRET}") String ACCESS_SECRET_KEY,
+        @Value("${REFRESH_SECRET}") String REFRESH_SECRET_KEY,
+        @Value("${ACCESS_EXPIRATION}") long ACCESS_EXPIRATION,
+        @Value("${REFRESH_EXPIRATION}") long REFRESH_EXPIRATION
     ) {
         this.customUserDetailService = customUserDetailService;
         this.jwtGenerator = jwtGenerator;

--- a/src/main/java/com/moneyplan/common/auth/JwtService.java
+++ b/src/main/java/com/moneyplan/common/auth/JwtService.java
@@ -40,10 +40,10 @@ public class JwtService {
 
     public JwtService(CustomUserDetailService customUserDetailService, JwtGenerator jwtGenerator,
         JwtUtil jwtUtil, RefreshTokenRepository refreshTokenRepository,
-        @Value("${ACCESS_SECRET}") String ACCESS_SECRET_KEY,
-        @Value("${REFRESH_SECRET}") String REFRESH_SECRET_KEY,
-        @Value("${ACCESS_EXPIRATION}") long ACCESS_EXPIRATION,
-        @Value("${REFRESH_EXPIRATION}") long REFRESH_EXPIRATION
+        @Value("${jwt.key.access}") String ACCESS_SECRET_KEY,
+        @Value("${jwt.key.refresh}") String REFRESH_SECRET_KEY,
+        @Value("${jwt.time.access}") long ACCESS_EXPIRATION,
+        @Value("${jwt.time.access}") long REFRESH_EXPIRATION
     ) {
         this.customUserDetailService = customUserDetailService;
         this.jwtGenerator = jwtGenerator;

--- a/src/main/java/com/moneyplan/common/auth/JwtService.java
+++ b/src/main/java/com/moneyplan/common/auth/JwtService.java
@@ -40,10 +40,10 @@ public class JwtService {
 
     public JwtService(CustomUserDetailService customUserDetailService, JwtGenerator jwtGenerator,
         JwtUtil jwtUtil, RefreshTokenRepository refreshTokenRepository,
-        @Value("${ACCESS_SECRET}") String ACCESS_SECRET_KEY,
-        @Value("${REFRESH_SECRET}") String REFRESH_SECRET_KEY,
-        @Value("${ACCESS_EXPIRATION}") long ACCESS_EXPIRATION,
-        @Value("${REFRESH_EXPIRATION}") long REFRESH_EXPIRATION
+        @Value("${jwt.key.access}") String ACCESS_SECRET_KEY,
+        @Value("${jwt.key.refresh}") String REFRESH_SECRET_KEY,
+        @Value("${jwt.time.access}") long ACCESS_EXPIRATION,
+        @Value("${jwt.time.refresh}") long REFRESH_EXPIRATION
     ) {
         this.customUserDetailService = customUserDetailService;
         this.jwtGenerator = jwtGenerator;

--- a/src/main/java/com/moneyplan/common/auth/JwtService.java
+++ b/src/main/java/com/moneyplan/common/auth/JwtService.java
@@ -1,0 +1,160 @@
+package com.moneyplan.common.auth;
+
+import com.moneyplan.common.auth.model.JwtRule;
+import com.moneyplan.common.auth.model.TokenStatus;
+import com.moneyplan.common.exception.BusinessException;
+import com.moneyplan.common.exception.ErrorCode;
+import com.moneyplan.common.util.JwtGenerator;
+import com.moneyplan.common.util.JwtUtil;
+import com.moneyplan.member.domain.Member;
+import com.moneyplan.refresh_token.domain.RefreshToken;
+import com.moneyplan.refresh_token.repository.RefreshTokenRepository;
+import io.jsonwebtoken.Jwts;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.security.Key;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@Slf4j
+public class JwtService {
+
+    private final CustomUserDetailService customUserDetailService;
+    private final JwtGenerator jwtGenerator;
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    private final Key ACCESS_SECRET_KEY;
+    private final Key REFRESH_SECRET_KEY;
+    private final long ACCESS_EXPIRATION;
+    private final long REFRESH_EXPIRATION;
+
+    public JwtService(CustomUserDetailService customUserDetailService, JwtGenerator jwtGenerator,
+        JwtUtil jwtUtil, RefreshTokenRepository refreshTokenRepository,
+        @Value("${ACCESS_SECRET}") String ACCESS_SECRET_KEY,
+        @Value("${REFRESH_SECRET}") String REFRESH_SECRET_KEY,
+        @Value("${ACCESS_EXPIRATION}") long ACCESS_EXPIRATION,
+        @Value("${REFRESH_EXPIRATION}") long REFRESH_EXPIRATION
+    ) {
+        this.customUserDetailService = customUserDetailService;
+        this.jwtGenerator = jwtGenerator;
+        this.jwtUtil = jwtUtil;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.ACCESS_SECRET_KEY = jwtUtil.getSigningKey(ACCESS_SECRET_KEY);
+        this.REFRESH_SECRET_KEY = jwtUtil.getSigningKey(REFRESH_SECRET_KEY);
+        this.ACCESS_EXPIRATION = ACCESS_EXPIRATION;
+        this.REFRESH_EXPIRATION = REFRESH_EXPIRATION;
+    }
+
+    public String generateAccessToken(HttpServletResponse response, Member requestMember) {
+        String accessToken = jwtGenerator.generateAccessToken(ACCESS_SECRET_KEY, ACCESS_EXPIRATION,
+            requestMember);
+        ResponseCookie cookie = setTokenToCookie(JwtRule.ACCESS_PREFIX.getValue(), accessToken,
+            ACCESS_EXPIRATION / 1000);
+        response.addHeader(JwtRule.JWT_ISSUE_HEADER.getValue(), cookie.toString());
+
+        return accessToken;
+    }
+
+    @Transactional
+    public String generateRefreshToken(HttpServletResponse response, Member requestMember) {
+        String refreshToken = jwtGenerator.generateRefreshToken(REFRESH_SECRET_KEY,
+            REFRESH_EXPIRATION, requestMember);
+        ResponseCookie cookie = setTokenToCookie(JwtRule.REFRESH_PREFIX.getValue(), refreshToken,
+            REFRESH_EXPIRATION / 1000);
+        response.addHeader(JwtRule.JWT_ISSUE_HEADER.getValue(), cookie.toString());
+
+        refreshTokenRepository.save(
+            RefreshToken.builder()
+                .member(requestMember)
+                .token(refreshToken)
+                .build());
+
+        return refreshToken;
+    }
+
+    /*
+     * Cookie에 토큰 저장
+     */
+    private ResponseCookie setTokenToCookie(String tokenPrefix, String token, long maxAgeSeconds) {
+        return ResponseCookie.from(tokenPrefix, token)
+            .path("/")
+            .maxAge(maxAgeSeconds)
+            .httpOnly(true)
+            .sameSite("Lax")
+            .secure(false)
+            .build();
+    }
+
+    /*
+     * Cookie에서 원하는 토큰 추출
+     */
+    public String resolveTokenFromCookie(HttpServletRequest request, JwtRule tokenPrefix) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            throw new BusinessException(ErrorCode.MISSING_TOKEN_IN_COOKIE);
+        }
+        return jwtUtil.resolveTokenFromCookie(cookies, tokenPrefix);
+    }
+
+    public boolean validateAccessToken(String token) {
+        return jwtUtil.getTokenStatus(token, ACCESS_SECRET_KEY) == TokenStatus.AUTHENTICATED;
+    }
+
+    public boolean validateRefreshToken(String token, Long memberId) {
+        boolean isRefreshValid = jwtUtil.getTokenStatus(token, REFRESH_SECRET_KEY) == TokenStatus.AUTHENTICATED;
+
+        RefreshToken storedToken = refreshTokenRepository.findByMember_Id(memberId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.JWT_TOKEN_NOT_FOUND));
+        boolean isTokenMatched = storedToken.getToken().equals(token);
+
+        return isRefreshValid && isTokenMatched;
+    }
+
+    public Authentication getAuthentication(String token) {
+        UserDetails principal = customUserDetailService.loadUserByUsername(getMemberPk(token, ACCESS_SECRET_KEY));
+        return new UsernamePasswordAuthenticationToken(principal, "", principal.getAuthorities());
+    }
+
+    private String getMemberPk(String token, Key secretKey) {
+        return Jwts.parserBuilder()
+            .setSigningKey(secretKey)
+            .build()
+            .parseClaimsJws(token)
+            .getBody()
+            .getSubject();
+    }
+
+    public String getIdFromRefresh(String refreshToken) {
+        try {
+            return Jwts.parserBuilder()
+                .setSigningKey(REFRESH_SECRET_KEY)
+                .build()
+                .parseClaimsJws(refreshToken)
+                .getBody()
+                .getSubject();
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.INVALID_JWT_TOKEN);
+        }
+    }
+
+    public void logout(Member requestMember, HttpServletResponse response) {
+        refreshTokenRepository.deleteById(requestMember.getId());
+
+        Cookie accessCookie = jwtUtil.resetToken(JwtRule.ACCESS_PREFIX);
+        Cookie refreshCookie = jwtUtil.resetToken(JwtRule.REFRESH_PREFIX);
+
+        response.addCookie(accessCookie);
+        response.addCookie(refreshCookie);
+    }
+
+}

--- a/src/main/java/com/moneyplan/common/auth/MemberAdapter.java
+++ b/src/main/java/com/moneyplan/common/auth/MemberAdapter.java
@@ -1,0 +1,17 @@
+package com.moneyplan.common.auth;
+
+import com.moneyplan.member.domain.Member;
+import java.util.Collections;
+import lombok.Getter;
+import org.springframework.security.core.userdetails.User;
+
+@Getter
+public class MemberAdapter extends User {
+
+    private Member member;
+
+    public MemberAdapter(Member member) {
+        super(member.getAccount(), member.getPassword(), Collections.emptyList());
+        this.member = member;
+    }
+}

--- a/src/main/java/com/moneyplan/common/auth/UserPrincipal.java
+++ b/src/main/java/com/moneyplan/common/auth/UserPrincipal.java
@@ -1,0 +1,33 @@
+package com.moneyplan.common.auth;
+
+import com.moneyplan.member.domain.Member;
+import java.util.Collection;
+import java.util.Collections;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+public class UserPrincipal implements UserDetails {
+
+    private final Member member;
+
+    public UserPrincipal(Member member) {
+        this.member = member;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(member.getId());
+    }
+}

--- a/src/main/java/com/moneyplan/common/auth/model/AuthUser.java
+++ b/src/main/java/com/moneyplan/common/auth/model/AuthUser.java
@@ -1,0 +1,14 @@
+package com.moneyplan.common.auth.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : member")
+public @interface AuthUser {
+
+}

--- a/src/main/java/com/moneyplan/common/auth/model/JwtRule.java
+++ b/src/main/java/com/moneyplan/common/auth/model/JwtRule.java
@@ -1,0 +1,15 @@
+package com.moneyplan.common.auth.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum JwtRule {
+    JWT_ISSUE_HEADER("Set-Cookie"),
+    JWT_RESOLVE_HEADER("Cookie"),
+    ACCESS_PREFIX("access"),
+    REFRESH_PREFIX("refresh");
+
+    private final String value;
+}

--- a/src/main/java/com/moneyplan/common/auth/model/SecurityConstants.java
+++ b/src/main/java/com/moneyplan/common/auth/model/SecurityConstants.java
@@ -1,0 +1,11 @@
+package com.moneyplan.common.auth.model;
+
+public class SecurityConstants {
+
+    public static final String[] PERMITTED_URI = {
+        "/h2-console/**","/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
+        "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/v1/members/**",
+        "/favicon.ico/**"
+    };
+
+}

--- a/src/main/java/com/moneyplan/common/auth/model/TokenStatus.java
+++ b/src/main/java/com/moneyplan/common/auth/model/TokenStatus.java
@@ -1,0 +1,12 @@
+package com.moneyplan.common.auth.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TokenStatus {
+    AUTHENTICATED,
+    EXPIRED,
+    INVALID
+}

--- a/src/main/java/com/moneyplan/common/config/OpenApiConfig.java
+++ b/src/main/java/com/moneyplan/common/config/OpenApiConfig.java
@@ -1,7 +1,12 @@
 package com.moneyplan.common.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.In;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,9 +15,10 @@ public class OpenApiConfig {
 
     @Bean
     public OpenAPI customOpenAPI() {
+
         return new OpenAPI()
                 .info(new Info()
-                        .title("GoldMarket Auth-Server API Docs"));
+                .title("MoneyPlan API Docs"));
     }
 }
 

--- a/src/main/java/com/moneyplan/common/exception/ErrorCode.java
+++ b/src/main/java/com/moneyplan/common/exception/ErrorCode.java
@@ -19,16 +19,27 @@ public enum ErrorCode {
     INVALID_AMOUNT_EXCEPTION(HttpStatus.BAD_REQUEST, "예산 금액은 0 이상이어야 합니다."),
 
     /**
+     * 401 - Unauthorized
+     */
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "계정명 또는 비밀번호가 틀렸습니다."),
+    INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "유효기간이 만료된 토큰입니다."),
+    MISSING_TOKEN_IN_COOKIE(HttpStatus.UNAUTHORIZED, "쿠키에 토큰이 존재하지 않습니다."),
+    MISSING_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "인증 정보가 존재하지 않습니다."),
+
+    /**
      * 404 - Not Found
      */
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
     EXPENSE_NOT_FOUND(HttpStatus.NOT_FOUND, "지출을 찾을 수 없습니다."),
+    JWT_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "토큰을 찾을 수 없습니다."),
 
     /**
      * 403 - Forbidden
      */
     ACCOUNT_CONFLICT(HttpStatus.CONFLICT, "이미 사용중인 계정입니다."),
+    FORBIDDEN_ACCESS(HttpStatus.CONFLICT, "접근 권한이 없습니다."),
 
     /**
      * 500 - Internal Server Error

--- a/src/main/java/com/moneyplan/common/exception/ExceptionHandlerFilter.java
+++ b/src/main/java/com/moneyplan/common/exception/ExceptionHandlerFilter.java
@@ -1,0 +1,46 @@
+package com.moneyplan.common.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            setErrorResponse(response, ErrorCode.EXPIRED_JWT_TOKEN);
+        } catch (JwtException | IllegalArgumentException e) {
+            setErrorResponse(response, ErrorCode.INVALID_JWT_TOKEN);
+        }
+    }
+
+    private void setErrorResponse(
+        HttpServletResponse response,
+        ErrorCode errorCode
+    ){
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        ResponseEntity<ErrorResponse<Void>> errorResponse = ErrorResponse.toResponseEntity(errorCode);
+        try{
+            response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+        }catch (IOException e){
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/moneyplan/common/util/JwtGenerator.java
+++ b/src/main/java/com/moneyplan/common/util/JwtGenerator.java
@@ -1,0 +1,61 @@
+package com.moneyplan.common.util;
+
+import com.moneyplan.member.domain.Member;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtGenerator {
+
+    public String generateAccessToken(final Key ACCESS_SECRET, final long ACCESS_EXPIRATION, Member member) {
+        Long now = System.currentTimeMillis();
+
+        return Jwts.builder()
+            .setHeader(createHeader())
+            .setClaims(createClaims(member))
+            .setSubject(String.valueOf(member.getId()))
+            .setIssuedAt(new Date(now))
+            .setExpiration(new Date(now + ACCESS_EXPIRATION))
+            .signWith(ACCESS_SECRET, SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+    public String generateRefreshToken(final Key REFRESH_SECRET, final long REFRESH_EXPIRATION, Member member) {
+        Long now = System.currentTimeMillis();
+
+        return Jwts.builder()
+            .setHeader(createHeader())
+            .setSubject(String.valueOf(member.getId()))
+            .setIssuedAt(new Date(now))
+            .setExpiration(new Date(now + REFRESH_EXPIRATION))
+            .signWith(REFRESH_SECRET, SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+    private Map<String, Object> createHeader() {
+        Header header = Jwts.header();
+        header.put("typ", "JWT");
+        header.put("alg", "HS256");
+        return header;
+    }
+
+    private Map<String, Object> createClaims(Member member) {
+        Claims claims = Jwts.claims();
+        claims.put("id", member.getId());
+        claims.put("account", member.getAccount());
+        return claims;
+    }
+
+}

--- a/src/main/java/com/moneyplan/common/util/JwtUtil.java
+++ b/src/main/java/com/moneyplan/common/util/JwtUtil.java
@@ -1,0 +1,64 @@
+package com.moneyplan.common.util;
+
+import com.moneyplan.common.exception.BusinessException;
+import com.moneyplan.common.exception.ErrorCode;
+import com.moneyplan.common.auth.model.JwtRule;
+import com.moneyplan.common.auth.model.TokenStatus;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Base64;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+public class JwtUtil {
+
+    public TokenStatus getTokenStatus(String token, Key secretKey) {
+        try {
+            Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token);
+            return TokenStatus.AUTHENTICATED;
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰입니다.", e);
+            return TokenStatus.EXPIRED;
+        } catch (JwtException e) {
+            throw new BusinessException(ErrorCode.INVALID_JWT_TOKEN);
+        }
+    }
+
+    public String resolveTokenFromCookie(Cookie[] cookies, JwtRule tokenPrefix) {
+        return Arrays.stream(cookies)
+            .filter(cookie -> cookie.getName().equals(tokenPrefix.getValue()))
+            .findFirst()
+            .map(Cookie::getValue)
+            .orElseThrow(() -> new BusinessException(ErrorCode.MISSING_TOKEN_IN_COOKIE));
+    }
+
+    public Key getSigningKey(String secretKey) {
+        String encodedKey = encodeToBase64(secretKey);
+        return Keys.hmacShaKeyFor(encodedKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String encodeToBase64(String secretKey) {
+        return Base64.getEncoder().encodeToString(secretKey.getBytes());
+    }
+
+    public Cookie resetToken(JwtRule tokenPrefix) {
+        Cookie cookie = new Cookie(tokenPrefix.getValue(), null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        return cookie;
+    }
+
+}

--- a/src/main/java/com/moneyplan/expense/controller/ExpenseController.java
+++ b/src/main/java/com/moneyplan/expense/controller/ExpenseController.java
@@ -1,10 +1,12 @@
 package com.moneyplan.expense.controller;
 
+import com.moneyplan.common.auth.model.AuthUser;
 import com.moneyplan.expense.dto.ExpenseReq;
 import com.moneyplan.expense.dto.ExpenseRes;
 import com.moneyplan.expense.dto.ExpensesRes;
 import com.moneyplan.expense.service.ExpenseService;
 import com.moneyplan.expense.service.filter.ExpenseFilter;
+import com.moneyplan.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -36,29 +38,29 @@ public class ExpenseController {
 
     @PostMapping("/")
     @Operation(summary = "지출 기록 생성", description = "지출 기록을 생성합니다.")
-    public ResponseEntity<ExpenseRes> createExpense(@RequestBody ExpenseReq req) {
-        ExpenseRes res = expenseService.createExpense(req);
+    public ResponseEntity<ExpenseRes> createExpense(@AuthUser Member member, @RequestBody ExpenseReq req) {
+        ExpenseRes res = expenseService.createExpense(member, req);
         return ResponseEntity.ok(res);
     }
 
     @PutMapping("/{id}")
     @Operation(summary = "지출 기록 수정", description = "지출 기록을 수정합니다.")
-    public ResponseEntity<ExpenseRes> updateExpense(@PathVariable Long id, @RequestBody ExpenseReq req) {
-        ExpenseRes res = expenseService.updateExpense(id, req);
+    public ResponseEntity<ExpenseRes> updateExpense(@AuthUser Member member, @PathVariable Long id, @RequestBody ExpenseReq req) {
+        ExpenseRes res = expenseService.updateExpense(member, id, req);
         return ResponseEntity.ok(res);
     }
 
     @DeleteMapping("/{id}")
     @Operation(summary = "지출 기록 삭제", description = "지출 기록을 삭제합니다.")
-    public ResponseEntity<String> deleteExpense(@PathVariable Long id) {
-        expenseService.deleteExpense(id);
+    public ResponseEntity<String> deleteExpense(@AuthUser Member member, @PathVariable Long id) {
+        expenseService.deleteExpense(member, id);
         return ResponseEntity.status(HttpStatus.OK).body("success");
     }
 
     @GetMapping("/{id}")
     @Operation(summary = "지출 기록 조회 (상세)", description = "지출 기록(상세)을 단건 조회합니다.")
-    public ResponseEntity<ExpenseRes> getExpense(@PathVariable Long id) {
-        ExpenseRes res = expenseService.getExpense(id);
+    public ResponseEntity<ExpenseRes> getExpense(@AuthUser Member member, @PathVariable Long id) {
+        ExpenseRes res = expenseService.getExpense(member, id);
         return ResponseEntity.ok(res);
     }
 
@@ -66,6 +68,7 @@ public class ExpenseController {
     @Operation(summary = "지출 기록 조회 (목록)", description = "기간별 지출 기록을 조회합니다. 지출 합계 및 "
         + "카테고리별 지출 합계를 함께 반환합니다. 카테고리, 최소 금액, 최대 금액을 지정할 수 있습니다(선택).")
     public ResponseEntity<ExpensesRes> getExpenses(
+        @AuthUser Member member,
         @Parameter(description = "시작일", example = "2024-09-01T00:00:00")
         @RequestParam @NotNull LocalDateTime startDate,
         @Parameter(description = "종료일", example = "2024-09-30T23:59:59")
@@ -89,7 +92,7 @@ public class ExpenseController {
             .maxAmount(maxAmount)
             .build();
 
-        ExpensesRes res = expenseService.getExpenses(page, size, filter);
+        ExpensesRes res = expenseService.getExpenses(member, page, size, filter);
         return ResponseEntity.ok(res);
     }
 }

--- a/src/main/java/com/moneyplan/expense/repository/custom/ExpenseCustomRepositoryImpl.java
+++ b/src/main/java/com/moneyplan/expense/repository/custom/ExpenseCustomRepositoryImpl.java
@@ -37,7 +37,7 @@ public class ExpenseCustomRepositoryImpl implements ExpenseCustomRepository{
         JPAQuery<Long> countQuery = jpaQueryFactory
             .select(expense.count())
             .from(expense)
-            .where(categoryEq(filter.getCategoryId()));
+            .where(buildConditions(filter));
 
         return PageableExecutionUtils.getPage(expenses, pageable, countQuery::fetchOne);
     }
@@ -71,7 +71,8 @@ public class ExpenseCustomRepositoryImpl implements ExpenseCustomRepository{
     }
 
     private BooleanExpression buildConditions(ExpenseFilter filter) {
-        return expense.spentAt.goe(filter.getStartDate())
+        return expense.member.id.eq(filter.getMemberId())
+            .and(expense.spentAt.goe(filter.getStartDate()))
             .and(expense.spentAt.loe(filter.getEndDate()))
             .and(categoryEq(filter.getCategoryId()))
             .and(amountGoe(filter.getMinAmount()))

--- a/src/main/java/com/moneyplan/expense/service/ExpenseService.java
+++ b/src/main/java/com/moneyplan/expense/service/ExpenseService.java
@@ -34,13 +34,11 @@ public class ExpenseService {
     private final CategoryRepository categoryRepository;
 
     @Transactional
-    public ExpenseRes createExpense(ExpenseReq req) {
+    public ExpenseRes createExpense(Member member, ExpenseReq req) {
 
-        // 회원가입/로그인 구현 전 임시 코드
-        Member member = memberRepository.findById(1L)
-            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-        // 임시 코드 끝
-
+        if (member == null) {
+            throw new BusinessException(ErrorCode.MISSING_AUTHENTICATION);
+        }
         Category category = categoryRepository.findById(req.getCategoryId())
             .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
 
@@ -51,15 +49,9 @@ public class ExpenseService {
     }
 
     @Transactional
-    public ExpenseRes updateExpense(Long id, ExpenseReq req) {
+    public ExpenseRes updateExpense(Member member, Long id, ExpenseReq req) {
 
-        // 회원가입/로그인 구현 전 임시 코드
-        Member member = memberRepository.findById(1L)
-            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-        // 임시 코드 끝
-
-        Expense expense = expenseRepository.findById(id)
-            .orElseThrow(() -> new BusinessException(ErrorCode.EXPENSE_NOT_FOUND));
+        Expense expense = verifyAccess(member, id);
 
         Category category = categoryRepository.findById(req.getCategoryId())
             .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
@@ -70,40 +62,24 @@ public class ExpenseService {
     }
 
     @Transactional
-    public void deleteExpense(Long id) {
-
-        // 회원가입/로그인 구현 전 임시 코드
-        Member member = memberRepository.findById(1L)
-            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-        // 임시 코드 끝
-
-        Expense expense = expenseRepository.findById(id)
-            .orElseThrow(() -> new BusinessException(ErrorCode.EXPENSE_NOT_FOUND));
-
+    public void deleteExpense(Member member, Long id) {
+        verifyAccess(member, id);
         expenseRepository.deleteById(id);
     }
 
     @Transactional
-    public ExpenseRes getExpense(Long id) {
-
-        // 회원가입/로그인 구현 전 임시 코드
-        Member member = memberRepository.findById(1L)
-            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-        // 임시 코드 끝
-
-        Expense expense = expenseRepository.findById(id)
-            .orElseThrow(() -> new BusinessException(ErrorCode.EXPENSE_NOT_FOUND));
-
+    public ExpenseRes getExpense(Member member, Long id) {
+        Expense expense = verifyAccess(member, id);
         return ExpenseRes.of(expense);
     }
 
     @Transactional
-    public ExpensesRes getExpenses(int page, int size, ExpenseFilter filter) {
+    public ExpensesRes getExpenses(Member member, int page, int size, ExpenseFilter filter) {
 
-        // 회원가입/로그인 구현 전 임시 코드
-        Member member = memberRepository.findById(1L)
-            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-        // 임시 코드 끝
+        if (member == null) {
+            throw new BusinessException(ErrorCode.MISSING_AUTHENTICATION);
+        }
+        filter.updateMemberId(member.getId());
 
         Pageable paging = PageRequest.of(page, size);
         Page<Expense> expensePage = expenseRepository.findWithFilters(paging, filter);
@@ -122,5 +98,18 @@ public class ExpenseService {
             .totalAmount(totalAmount)
             .expenseCategoryTotals(categoryTotals)
             .build();
+    }
+
+    private Expense verifyAccess(Member member, Long expenseId) {
+        if (member == null) {
+            throw new BusinessException(ErrorCode.MISSING_AUTHENTICATION);
+        }
+        Expense expense = expenseRepository.findById(expenseId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.EXPENSE_NOT_FOUND));
+
+        if (member.getId() != expense.getMember().getId()) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+        return expense;
     }
 }

--- a/src/main/java/com/moneyplan/expense/service/filter/ExpenseFilter.java
+++ b/src/main/java/com/moneyplan/expense/service/filter/ExpenseFilter.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 @Getter
 public class ExpenseFilter {
 
+    Long memberId;
+
     LocalDateTime startDate;
     LocalDateTime endDate;
     Long categoryId;
@@ -14,12 +16,17 @@ public class ExpenseFilter {
     Integer maxAmount;
 
     @Builder
-    public ExpenseFilter(LocalDateTime startDate, LocalDateTime endDate, Long categoryId,
+    public ExpenseFilter(Long memberId, LocalDateTime startDate, LocalDateTime endDate, Long categoryId,
         Integer minAmount, Integer maxAmount) {
+        this.memberId = memberId;
         this.startDate = startDate;
         this.endDate = endDate;
         this.categoryId = categoryId;
         this.minAmount = minAmount;
         this.maxAmount = maxAmount;
+    }
+
+    public void updateMemberId(Long memberId) {
+        this.memberId = memberId;
     }
 }

--- a/src/main/java/com/moneyplan/member/controller/MemberController.java
+++ b/src/main/java/com/moneyplan/member/controller/MemberController.java
@@ -1,11 +1,14 @@
 package com.moneyplan.member.controller;
 
+import com.moneyplan.member.dto.LoginMemberReq;
+import com.moneyplan.member.dto.LoginMemberRes;
 import com.moneyplan.member.dto.MemberReq;
 import com.moneyplan.member.dto.MemberRes;
 import com.moneyplan.member.repository.MemberRepository;
 import com.moneyplan.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -30,5 +33,12 @@ public class MemberController {
         return ResponseEntity.ok(res);
     }
 
+    @PostMapping("/login")
+    @Operation(summary = "로그인", description = "계정명과 비밀번호로 로그인을 합니다.")
+    public ResponseEntity<LoginMemberRes> login(HttpServletResponse httpRes,
+        @Valid @RequestBody LoginMemberReq req) {
 
+        LoginMemberRes res = memberService.login(httpRes, req);
+        return ResponseEntity.ok(res);
+    }
 }

--- a/src/main/java/com/moneyplan/member/domain/Member.java
+++ b/src/main/java/com/moneyplan/member/domain/Member.java
@@ -5,11 +5,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/moneyplan/member/dto/LoginMemberReq.java
+++ b/src/main/java/com/moneyplan/member/dto/LoginMemberReq.java
@@ -1,0 +1,21 @@
+package com.moneyplan.member.dto;
+
+import com.moneyplan.member.domain.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "AUTH_REQ_02 : 로그인 요청 DTO")
+public class LoginMemberReq {
+
+    @Schema(description = "계정명", example = "MoneyPlan")
+    @NotBlank(message = "계정명은 필수 입력 값입니다.")
+    private String account;
+
+    @Schema(description = "비밀번호", example = "password1234@")
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    private String password;
+}

--- a/src/main/java/com/moneyplan/member/dto/LoginMemberRes.java
+++ b/src/main/java/com/moneyplan/member/dto/LoginMemberRes.java
@@ -1,0 +1,25 @@
+package com.moneyplan.member.dto;
+
+import com.moneyplan.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginMemberRes {
+
+    private Long id;
+    private String account;
+    private String accessToken;
+    private String refreshToken;
+
+    public static LoginMemberRes of(Member member, String accessToken, String refreshToken) {
+        return LoginMemberRes.builder()
+            .id(member.getId())
+            .account(member.getAccount())
+            .accessToken(accessToken)
+            .refreshToken(refreshToken)
+            .build();
+    }
+
+}

--- a/src/main/java/com/moneyplan/member/service/MemberService.java
+++ b/src/main/java/com/moneyplan/member/service/MemberService.java
@@ -1,11 +1,15 @@
 package com.moneyplan.member.service;
 
+import com.moneyplan.common.auth.JwtService;
 import com.moneyplan.common.exception.BusinessException;
 import com.moneyplan.common.exception.ErrorCode;
 import com.moneyplan.member.domain.Member;
+import com.moneyplan.member.dto.LoginMemberReq;
+import com.moneyplan.member.dto.LoginMemberRes;
 import com.moneyplan.member.dto.MemberReq;
 import com.moneyplan.member.dto.MemberRes;
 import com.moneyplan.member.repository.MemberRepository;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -15,8 +19,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
 
-    private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder encoder;
+    private final MemberRepository memberRepository;
+    private final JwtService jwtService;
 
     @Transactional
     public MemberRes register(MemberReq req) {
@@ -30,5 +35,20 @@ public class MemberService {
         memberRepository.save(member);
 
         return MemberRes.of(member);
+    }
+
+    @Transactional
+    public LoginMemberRes login(HttpServletResponse httpRes, LoginMemberReq req) {
+
+        Member member = memberRepository.findByAccount(req.getAccount())
+            .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
+
+        if (!encoder.matches(req.getPassword(), member.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
+        }
+        String accessToken = jwtService.generateAccessToken(httpRes, member);
+        String refreshToken = jwtService.generateRefreshToken(httpRes, member);
+
+        return LoginMemberRes.of(member, accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/moneyplan/refresh_token/domain/RefreshToken.java
+++ b/src/main/java/com/moneyplan/refresh_token/domain/RefreshToken.java
@@ -9,10 +9,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RefreshToken {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,4 +28,10 @@ public class RefreshToken {
 
     @Column(nullable = false)
     private String token;
+
+    @Builder
+    public RefreshToken(Member member, String token) {
+        this.member = member;
+        this.token = token;
+    }
 }

--- a/src/main/java/com/moneyplan/refresh_token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/moneyplan/refresh_token/repository/RefreshTokenRepository.java
@@ -1,10 +1,13 @@
 package com.moneyplan.refresh_token.repository;
 
 import com.moneyplan.refresh_token.domain.RefreshToken;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByMember_Id(Long id);
 
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,6 +1,4 @@
 spring:
-  config:
-    import: application-secret.properties
   datasource:
     url: ${RDS_URL}
     username: ${RDS_USERNAME}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,6 +13,3 @@ spring:
   sql:
     init:
       mode: always
-
-jwt:
-  secret: ${JWT_SECRET}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,6 +1,4 @@
 spring:
-  config:
-    import: application-secret.properties
   datasource:
     url: jdbc:h2:mem:testdb;MODE=MYSQL;DATABASE_TO_LOWER=TRUE
     username: sa

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,8 +1,6 @@
 spring:
-  config:
-    import: application-secret.properties
   datasource:
     url: ${RDS_URL}
     username: ${RDS_USERNAME}
     password: ${RDS_PASSWORD}
-    driver-class-name: org.mariadb.jdbc.Driver
+    driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: application-secret.properties
   sql:
     init:
       mode: never
@@ -10,11 +12,3 @@ spring:
         show_sql: true
         format_sql: true
     open-in-view: false
-    
-jwt:
-  key:
-    access: ${ACCESS_SECRET}
-    refresh: ${REFRESH_SECRET}
-  time:
-    access: ${ACCESS_EXPIRATION}
-    refresh: ${REFRESH_EXPIRATION}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,11 @@ spring:
         show_sql: true
         format_sql: true
     open-in-view: false
+
+jwt:
+  key:
+    access: ${ACCESS_SECRET}
+    refresh: ${REFRESH_SECRET}
+  time:
+    access: ${ACCESS_EXPIRATION}
+    refresh: ${REFRESH_EXPIRATION}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,11 @@ spring:
         show_sql: true
         format_sql: true
     open-in-view: false
+    
+jwt:
+  key:
+    access: ${ACCESS_SECRET}
+    refresh: ${REFRESH_SECRET}
+  time:
+    access: ${ACCESS_EXPIRATION}
+    refresh: ${REFRESH_EXPIRATION}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,11 +12,3 @@ spring:
         show_sql: true
         format_sql: true
     open-in-view: false
-
-jwt:
-  key:
-    access: ${ACCESS_SECRET}
-    refresh: ${REFRESH_SECRET}
-  time:
-    access: ${ACCESS_EXPIRATION}
-    refresh: ${REFRESH_EXPIRATION}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,5 +1,8 @@
 INSERT IGNORE INTO member (id, account, password)
-VALUES (1, 'moneyplan', '$2a$10$cAz0EmZYfqzngI46j91lX.GdJ9hlmYbMsOa5Esr0Hh.rwyfDb8dYW');
+-- password1234@
+VALUES
+(1, 'MoneyPlan', '$2a$10$mIyRde.YyDr8fvyaXpCJPO0Go.f7oG/8dsLngB9hTTA4imzajK6Q6'),
+(2, 'MoneyMap', '$2a$10$P9RH4WZ2JRe6miyoJjV1vuSIUh073yIgLDANukaUHq2sXuo8EOWzO');
 
 INSERT IGNORE INTO category (name)
 VALUES
@@ -17,6 +20,7 @@ VALUES
 
 INSERT IGNORE INTO expense (spent_at, amount, memo, is_total_excluded, member_id, category_id)
 VALUES
+-- MoneyPlan
 -- 식비
 ('2024-09-02 19:30:00', 9000, '친구들 만나서 저녁식사 했음', false, 1, 1),
 ('2024-09-04 20:00:00', 3900, '편의점 샌드위치', false, 1, 1),
@@ -33,4 +37,25 @@ VALUES
 ('2024-09-11 9:00:00', 35000, '방구석 뮤지컬 티켓값', false, 1, 6),
 
 -- 기타
-('2024-09-10 01:20:00', 100000, '친구한테 빌려줌', true, 1, 11);
+('2024-09-10 01:20:00', 100000, '친구한테 빌려줌', true, 1, 11),
+
+-- MoneyMap
+-- 식비
+('2024-09-03 19:30:00', 12000, '선배랑 점심에 초밥', false, 2, 1),
+('2024-09-07 20:00:00', 7200, '버거킹', false, 2, 1),
+('2024-09-24 09:00:00', 5400, '간식', false, 2, 1),
+('2024-09-26 14:00:00', 3000, null, false, 2, 1),
+
+-- 패션
+('2024-09-01 17:20:00', 50000, '청바지', false, 2, 5),
+('2024-09-13 17:20:00', 10000, '무지티 1장', false, 2, 5),
+('2024-09-14 17:20:00', 33000, '빈티지 셔츠', false, 2, 5),
+
+-- 여가
+('2024-09-02 20:10:00', 7000, '네이버웹툰 캐시 결제', false, 2, 6),
+('2024-09-07 13:20:00', 48200, '오첨뮤 티켓값', true, 2, 6),
+('2024-09-11 9:00:00', 35000, '브론테 티켓값', true, 2, 6),
+
+-- 교육
+('2024-09-29 01:20:00', 30000, '정처기 실기 교재 구매', true, 2, 10);
+


### PR DESCRIPTION
## 🔥 구현 기능
> 로그인 API 및 기존 API에서 미구현 상태였던 사용자 권한 체크를 구현했습니다.

## 🔥 구현 방법
- 로그인 시 Access token 및 Refresh token을 response cookie에 저장하여 로그인 상태를 유지하도록 했습니다.
- RTR 기법을 활용해 AT 만료 시 RT도 재발급하도록 구현했습니다.
- AuthUser 어노테이션을 구현하여 사용자 권한 체크가 필요한 API에서 사용자 정보를 가져올 수 있도록 했습니다.

## 🔥 관련 이슈
related: #19 
    
## 참고 할만한 자료(선택)
